### PR TITLE
using version for update check instead of timestamp

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Parameter | Description
 `options.headers` | `Object` _(Optional)_ Set of headers to use when requesting the remote content from `options.src`.
 `options.archiveURL` | `String` _(Mandatory if `options.type === 'replace'`)_ URL of the zip containing the files to hot push.
 `options.documentsPath` | `Object` _(Optional)_ Path to the Documents folder (useful for [WKWebView](https://github.com/etiennea/WKWebView))
+`options.versionType` | `String` _(Optional)_ Set to 'package.json' if you want to use the version number in your version.json instead of timestamp
 
 ### Returns
 

--- a/plugin.xml
+++ b/plugin.xml
@@ -15,7 +15,7 @@
 
   <issue>https://github.com/mathieudutour/cordova-plugin-hotpushes/issues</issue>
 
-  <dependency id="com.adobe.phonegap.contentsync" url="https://github.com/phonegap/phonegap-plugin-contentsync" commit="58040c2cceb3b1cb71e1a367603bbf6d2a0ee70e" />
+  <dependency id="phonegap-plugin-contentsync" url="https://github.com/phonegap/phonegap-plugin-contentsync" tag="1.1.6" />
 
   <js-module src="www/index.js" name="HotPush">
     <clobbers target="window.HotPush" />

--- a/www/index.js
+++ b/www/index.js
@@ -152,19 +152,7 @@ HotPush.prototype._hasloadedLocalFile = function() {
 HotPush.prototype.update = function() {
   var self = this;
   if (this.options.type === 'replace') {
-    //this._syncs = [ContentSync.sync({ src: this.options.archiveURL, id: 'assets', headers: this.options.headers})];
-    this._syncs = [ContentSync.download( this.options.archiveURL, this.options.headers, function(response) {
-      console.log("ContentSync Download Callback");
-      if(response.progress) {
-        console.log(response);
-      }
-      if(response.archiveURL) {
-        var archiveURL = response.archiveURL;
-        Zip.unzip(archiveURL, "file://data/data/de.mobilexag.mip.cordovareact/android_asset/www", function(response) {
-          console.log(response);
-        })
-      }
-    })];
+    this._syncs = [ContentSync.sync({ src: this.options.archiveURL, id: 'assets', type: 'replace', copyCordovaAssets: true, headers: this.options.headers})];
 
     this._syncs[0].on('progress', function(data) {
       self.emit('progress', data);
@@ -175,9 +163,8 @@ HotPush.prototype.update = function() {
       localStorage.setItem("hotpushes_localVersion", JSON.stringify(self.remoteVersion));
       console.log('downloaded file:');
       console.log(data.localPath);
-      //ContentSync.unzip("/data/data/de.mobilexag.mip.cordovareact/files/files/assets", "/data/data/de.mobilexag.mip.cordovareact/android_asset/www")
       //this._extract(data.localPath);
-      self.emit('updateComplete');
+      self.emit('updateComplete', data.localPath);
     });
 
     this._syncs[0].on('error', function(e) {
@@ -188,12 +175,6 @@ HotPush.prototype.update = function() {
     this.emit('error', new Error('not implemented yet'));
   }
 };
-
-HotPush.prototype._extract = function(zipPath) {
-  var self = this;
-  ContentSync.unzip(zipPath)
-  self.emit('updateComplete');
-}
 
 /**
 * Get the path to a local file

--- a/www/index.js
+++ b/www/index.js
@@ -152,7 +152,11 @@ HotPush.prototype._hasloadedLocalFile = function() {
 HotPush.prototype.update = function() {
   var self = this;
   if (this.options.type === 'replace') {
-    this._syncs = [ContentSync.sync({ src: this.options.archiveURL, id: 'assets', headers: this.options.headers})];
+    //this._syncs = [ContentSync.sync({ src: this.options.archiveURL, id: 'assets', headers: this.options.headers})];
+    this._syncs = [ContentSync.download( this.options.archiveURL, "file://data/data/de.mobilexag.mip.cordovareact/android_asset/www", function(message) {
+      console.log("ContentSync Download Callback");
+      console.log(message);
+    })];
 
     this._syncs[0].on('progress', function(data) {
       self.emit('progress', data);
@@ -163,6 +167,7 @@ HotPush.prototype.update = function() {
       localStorage.setItem("hotpushes_localVersion", JSON.stringify(self.remoteVersion));
       console.log('downloaded file:');
       console.log(data.localPath);
+      //ContentSync.unzip("/data/data/de.mobilexag.mip.cordovareact/files/files/assets", "/data/data/de.mobilexag.mip.cordovareact/android_asset/www")
       //this._extract(data.localPath);
       self.emit('updateComplete');
     });

--- a/www/index.js
+++ b/www/index.js
@@ -158,9 +158,12 @@ HotPush.prototype.update = function() {
       self.emit('progress', data);
     });
 
-    this._syncs[0].on('complete', function() {
+    this._syncs[0].on('complete', function(data) {
       self.remoteVersion.location = 'documents';
       localStorage.setItem("hotpushes_localVersion", JSON.stringify(self.remoteVersion));
+      console.log('downloaded file:');
+      console.log(data.localPath);
+      //this._extract(data.localPath);
       self.emit('updateComplete');
     });
 
@@ -172,6 +175,12 @@ HotPush.prototype.update = function() {
     this.emit('error', new Error('not implemented yet'));
   }
 };
+
+HotPush.prototype._extract = function(zipPath) {
+  var self = this;
+  ContentSync.unzip(zipPath)
+  self.emit('updateComplete');
+}
 
 /**
 * Get the path to a local file

--- a/www/index.js
+++ b/www/index.js
@@ -240,15 +240,15 @@ HotPush.prototype._verifyVersions = function() {
 };
 
 HotPush.prototype._loadLocalFile = function(filename) {
-/*  var head = document.getElementsByTagName("head")[0];
+  var body = document.getElementsByTagName("body")[0];
   var domEl;
   var time = new Date().getTime();
-  if (filename.split('.css').length > 1) {
+  /*if (filename.split('.css').length > 1) {
     domEl = document.createElement("link");
     domEl.setAttribute("rel", "stylesheet");
     domEl.setAttribute("type", "text/css");
     domEl.setAttribute("href", this._getLocalPath(filename) + '?' + time);
-  } else if (filename.split('.js').length > 1) {
+  } else */if (filename.split('.js').length > 1) {
     domEl = document.createElement('script');
     domEl.setAttribute("type", "text/javascript");
     domEl.setAttribute("src", this._getLocalPath(filename) + '?' + time);
@@ -259,7 +259,7 @@ HotPush.prototype._loadLocalFile = function(filename) {
       this._hasloadedLocalFile();
     }.bind(this);
   }
-  head.appendChild(domEl);*/
+  body.appendChild(domEl);
   console.log('file:');
   console.log(filename);
 };

--- a/www/index.js
+++ b/www/index.js
@@ -153,9 +153,17 @@ HotPush.prototype.update = function() {
   var self = this;
   if (this.options.type === 'replace') {
     //this._syncs = [ContentSync.sync({ src: this.options.archiveURL, id: 'assets', headers: this.options.headers})];
-    this._syncs = [ContentSync.download( this.options.archiveURL, "file://data/data/de.mobilexag.mip.cordovareact/android_asset/www", function(message) {
+    this._syncs = [ContentSync.download( this.options.archiveURL, this.options.headers, function(response) {
       console.log("ContentSync Download Callback");
-      console.log(message);
+      if(response.progress) {
+        console.log(response);
+      }
+      if(response.archiveURL) {
+        var archiveURL = response.archiveURL;
+        Zip.unzip(archiveURL, "file://data/data/de.mobilexag.mip.cordovareact/android_asset/www", function(response) {
+          console.log(response);
+        })
+      }
     })];
 
     this._syncs[0].on('progress', function(data) {

--- a/www/index.js
+++ b/www/index.js
@@ -237,7 +237,7 @@ HotPush.prototype._verifyVersions = function() {
 };
 
 HotPush.prototype._loadLocalFile = function(filename) {
-  var head = document.getElementsByTagName("head")[0];
+/*  var head = document.getElementsByTagName("head")[0];
   var domEl;
   var time = new Date().getTime();
   if (filename.split('.css').length > 1) {
@@ -256,7 +256,9 @@ HotPush.prototype._loadLocalFile = function(filename) {
       this._hasloadedLocalFile();
     }.bind(this);
   }
-  head.appendChild(domEl);
+  head.appendChild(domEl);*/
+  console.log('file:');
+  console.log(filename);
 };
 
 /**

--- a/www/index.js
+++ b/www/index.js
@@ -4,7 +4,7 @@
  * Module dependencies.
  */
 
-var ContentSync = cordova.require('com.adobe.phonegap.contentsync.ContentSync');
+var ContentSync = cordova.require('phonegap-plugin-contentsync.ContentSync');
 
 /**
  * HotPush constructor.
@@ -66,6 +66,13 @@ var HotPush = function(options) {
 
   if (typeof options.documentsPath === 'undefined') {
     options.documentsPath = 'cdvfile://localhost/persistent/';
+  }
+
+  // optional version type for update checks
+  // default check method uses timestamp
+  // 'version' option will use the version number in your package.json
+  if (typeof options.versionType === 'undefined') {
+    options.versionType = null;
   }
 
   // store the options to this object instance
@@ -227,15 +234,23 @@ HotPush.prototype._loadLocalVersion = function(callback) {
 * Callback for async call to version files
 */
 HotPush.prototype._verifyVersions = function() {
-/*  if (this.localVersion.timestamp !== this.remoteVersion.timestamp) {
-    console.log('Not the last version, ' + this.localVersion.timestamp +' !== ' + this.remoteVersion.timestamp);*/
+  if(this.options.versionType === 'package.json') {
     if (this.localVersion.version !== this.remoteVersion.version) {
       console.log('Not the last version, ' + this.localVersion.version +' !== ' + this.remoteVersion.version);
-    this.emit('updateFound');
+      this.emit('updateFound');
+    } else {
+      console.log('All good, last version running');
+      this.emit('noUpdateFound');
+    }
   } else {
-    console.log('All good, last version running');
-    this.emit('noUpdateFound');
-  }
+    if (this.localVersion.timestamp !== this.remoteVersion.timestamp) {
+      console.log('Not the last version, ' + this.localVersion.timestamp +' !== ' + this.remoteVersion.timestamp);
+      this.emit('updateFound');
+    } else {
+      console.log('All good, last version running');
+      this.emit('noUpdateFound');
+    }
+  } 
 };
 
 HotPush.prototype._loadLocalFile = function(filename) {

--- a/www/index.js
+++ b/www/index.js
@@ -161,8 +161,6 @@ HotPush.prototype.update = function() {
     this._syncs[0].on('complete', function(data) {
       self.remoteVersion.location = 'documents';
       localStorage.setItem("hotpushes_localVersion", JSON.stringify(self.remoteVersion));
-      console.log('downloaded file:');
-      console.log(data.localPath);
       self.emit('updateComplete', data.localPath);
     });
 
@@ -241,7 +239,7 @@ HotPush.prototype._verifyVersions = function() {
 };
 
 HotPush.prototype._loadLocalFile = function(filename) {
-var head = document.getElementsByTagName("head")[0];
+  var head = document.getElementsByTagName("head")[0];
   var domEl;
   var time = new Date().getTime();
   if (filename.split('.css').length > 1) {
@@ -261,8 +259,6 @@ var head = document.getElementsByTagName("head")[0];
     }.bind(this);
   }
   head.appendChild(domEl);
-  console.log('file:');
-  console.log(filename);
 };
 
 /**

--- a/www/index.js
+++ b/www/index.js
@@ -152,7 +152,7 @@ HotPush.prototype._hasloadedLocalFile = function() {
 HotPush.prototype.update = function() {
   var self = this;
   if (this.options.type === 'replace') {
-    this._syncs = [ContentSync.sync({ src: this.options.archiveURL, id: 'assets', type: 'replace', copyCordovaAssets: true, headers: this.options.headers})];
+    this._syncs = [ContentSync.sync({ src: this.options.archiveURL, id: 'assets', copyCordovaAssets: true, headers: this.options.headers})];
 
     this._syncs[0].on('progress', function(data) {
       self.emit('progress', data);
@@ -163,7 +163,6 @@ HotPush.prototype.update = function() {
       localStorage.setItem("hotpushes_localVersion", JSON.stringify(self.remoteVersion));
       console.log('downloaded file:');
       console.log(data.localPath);
-      //this._extract(data.localPath);
       self.emit('updateComplete', data.localPath);
     });
 
@@ -230,8 +229,10 @@ HotPush.prototype._loadLocalVersion = function(callback) {
 * Callback for async call to version files
 */
 HotPush.prototype._verifyVersions = function() {
-  if (this.localVersion.timestamp !== this.remoteVersion.timestamp) {
-    console.log('Not the last version, ' + this.localVersion.timestamp +' !== ' + this.remoteVersion.timestamp);
+/*  if (this.localVersion.timestamp !== this.remoteVersion.timestamp) {
+    console.log('Not the last version, ' + this.localVersion.timestamp +' !== ' + this.remoteVersion.timestamp);*/
+    if (this.localVersion.version !== this.remoteVersion.version) {
+      console.log('Not the last version, ' + this.localVersion.version +' !== ' + this.remoteVersion.version);
     this.emit('updateFound');
   } else {
     console.log('All good, last version running');
@@ -240,15 +241,15 @@ HotPush.prototype._verifyVersions = function() {
 };
 
 HotPush.prototype._loadLocalFile = function(filename) {
-  var body = document.getElementsByTagName("body")[0];
+var head = document.getElementsByTagName("head")[0];
   var domEl;
   var time = new Date().getTime();
-  /*if (filename.split('.css').length > 1) {
+  if (filename.split('.css').length > 1) {
     domEl = document.createElement("link");
     domEl.setAttribute("rel", "stylesheet");
     domEl.setAttribute("type", "text/css");
     domEl.setAttribute("href", this._getLocalPath(filename) + '?' + time);
-  } else */if (filename.split('.js').length > 1) {
+  } else if (filename.split('.js').length > 1) {
     domEl = document.createElement('script');
     domEl.setAttribute("type", "text/javascript");
     domEl.setAttribute("src", this._getLocalPath(filename) + '?' + time);
@@ -259,7 +260,7 @@ HotPush.prototype._loadLocalFile = function(filename) {
       this._hasloadedLocalFile();
     }.bind(this);
   }
-  body.appendChild(domEl);
+  head.appendChild(domEl);
   console.log('file:');
   console.log(filename);
 };


### PR DESCRIPTION
I've modified the update check to look for a new version number instead of the timestamp.
The version number and the corresponding version.json can be generated with this modified [gulp-directory-map](https://github.com/chauthai/gulp-directory-map) for gulp.

I've build a test project with ReactJS and will publish it later. It includes production ready features like deletion of the old version when normal app store updates are applied.
